### PR TITLE
Additional pipeline to tag the image with latest

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -15,7 +15,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-appstudio/ec-golden-image:latest
+      value: 'quay.io/redhat-appstudio/ec-golden-image:{{revision}}'
     - name: dockerfile
       value: ./Containerfile
     - name: path-context

--- a/.tekton/tag-latest.yaml
+++ b/.tekton/tag-latest.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: contract-golden-image-on-tag-latest
+  annotations:
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: '[push]'
+    pipelinesascode.tekton.dev/on-target-branch: '[main]'
+spec:
+  params:
+    - name: revision
+      value: '{{revision}}'
+  pipelineSpec:
+    params:
+      - name: revision
+    tasks:
+      - name: tag-with-latest
+        params:
+          - name: revision
+            value: '$(params.revision)'
+        taskSpec:
+          params:
+            - name: revision
+          steps:
+            - name: tag-with-latest
+              image: registry.access.redhat.com/ubi9/skopeo:latest@sha256:23c9ed4af1f42614bdc56309452568b2110a67f23102f42f6a6582a63b63dcdb
+              script: |
+                #!/usr/bin/env bash
+                SRC_REF=quay.io/redhat-appstudio/ec-golden-image:$(params.revision)
+                TARGET_REF=quay.io/redhat-appstudio/ec-golden-image:latest
+
+                retries=0
+                while ! skopeo inspect docker://${SRC_REF} >/dev/null 2>&1; do
+                  (( retries++ ))
+                  if (( retries > 200 )); then
+                    echo
+                    echo ${SRC_REF} has not been pushed within 10 min
+                    exit 1
+                  fi
+                  echo -n .
+                  sleep 3
+                done
+                echo
+                echo ${SRC_REF} has been pushed, copying to ${TARGET_REF}
+
+                skopeo copy --authfile=/secret/default-push-secret/.dockerconfigjson docker://${SRC_REF} docker://${TARGET_REF}
+              volumeMounts:
+                - mountPath: /var/lib/containers
+                  name: varlibcontainers
+                - mountPath: /secret/default-push-secret
+                  name: default-push-secret
+          volumes:
+            - emptyDir: {}
+              name: varlibcontainers
+            - csi:
+                driver: csi.sharedresource.openshift.io
+                readOnly: true
+                volumeAttributes:
+                  sharedSecret: redhat-appstudio-user-workload
+              name: default-push-secret


### PR DESCRIPTION
~Runs a second pipeline to build and push an image tagged with the git commit id.~
Runs a second pipeline that waits 1 min for the first pipeline to push the image and then copies the image with the `latest` tag.